### PR TITLE
#29: Motor toggle action

### DIFF
--- a/Sources/Plugin/DeviceControl.xaml
+++ b/Sources/Plugin/DeviceControl.xaml
@@ -32,6 +32,8 @@
                                     <TextBlock TextWrapping="WrapWithOverflow" Margin="0,0,0,20">
                                             <Label Content="{SLoc SABT_Label_EnableMotors}" Margin="-5,0,0,0" />
                                             <styles:SHToggleCheckbox IsChecked="{Binding Settings.IsEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding Settings.IsSerialPortValid}" />
+                                            <Label Content="{SLoc SABT_Label_DisableActivationConfirmation}" Margin="-5,0,0,0" />
+                                            <styles:SHToggleCheckbox IsChecked="{Binding Settings.DisableActivationConfirmation, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                             <Label Content="{SLoc SABT_Label_StartAutomatically}" Margin="-5,0,0,0" />
                                             <styles:SHToggleCheckbox IsChecked="{Binding Settings.StartAutomatically, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                             <Label Content="{SLoc SABT_Label_FlipChannels}" Margin="-5,0,0,0" />

--- a/Sources/Plugin/DevicePlugin.cs
+++ b/Sources/Plugin/DevicePlugin.cs
@@ -86,6 +86,11 @@ namespace User.ActiveBeltTensioner
                 IsBackground = true,
                 Name = "SABT.ControlLoop"
             };
+
+            pluginManager.AddAction("toggleSabtMotors", (manager, inp) => {
+                Settings.IsEnabled = !Settings.IsEnabled;
+            });
+
             _controlThread.Start();
         }
 

--- a/Sources/Plugin/DevicePlugin.cs
+++ b/Sources/Plugin/DevicePlugin.cs
@@ -123,6 +123,26 @@ namespace User.ActiveBeltTensioner
                 }
             }
 
+            if (e.PropertyName == nameof(Settings.DisableActivationConfirmation) && Settings.DisableActivationConfirmation)
+            {
+                var result = MessageBoxResult.No;
+
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    result = MessageBox.Show(
+                        SLoc.GetValue("SABT_Message_DisableActivationWarningWarning"),
+                        SLoc.GetValue("SABT_Plugin"),
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Warning
+                    );
+                });
+
+                if (result != MessageBoxResult.Yes)
+                {
+                    Settings.DisableActivationConfirmation = false;
+                }
+            }
+
             if (
                 e.PropertyName == nameof(Settings.MinimumSurge) ||
                 e.PropertyName == nameof(Settings.MaximumSurge) ||
@@ -222,7 +242,7 @@ namespace User.ActiveBeltTensioner
                     motorController = MotorController;
                 }
 
-                if (_hasBeenInactive)
+                if (_hasBeenInactive && !Settings.DisableActivationConfirmation)
                 {
                     MessageBoxResult result = MessageBoxResult.No;
 

--- a/Sources/Plugin/DeviceSettings.cs
+++ b/Sources/Plugin/DeviceSettings.cs
@@ -58,6 +58,21 @@ namespace User.ActiveBeltTensioner
             }
         }
 
+        private bool _disableActivationConfirmation = false;
+        public bool DisableActivationConfirmation
+        {
+            get => _disableActivationConfirmation;
+            set
+            {
+                if (_disableActivationConfirmation != value) {
+                    _disableActivationConfirmation = value;
+                    InvokePropertyChange(nameof(DisableActivationConfirmation));
+                }
+               
+            }
+
+        }
+
         private bool _isFlipped = false;
         public bool IsFlipped
         {

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.de-DE.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.de-DE.resx
@@ -144,6 +144,9 @@
   <data name="SABT_Message_ActivationWarning" xml:space="preserve">
     <value>Die Motoren des Gurtstraffers werden aktiviert. Fortfahren?</value>
   </data>
+  <data name="SABT_Message_DisableActivationWarningWarning" xml:space="preserve">
+    <value>Dadurch wird die Bestätigungsabfrage vor der Aktivierung der Motoren deaktiviert; aktivieren Sie diese Option nur, wenn Sie genau wissen, was Sie tun. Fortfahren?</value>
+  </data>
   <data name="SABT_Message_SimHubLicenseRequired" xml:space="preserve">
     <value>Ihre SimHub-Installation ist nicht lizenziert, daher sind Telemetrie-Updates auf 10 Hz begrenzt</value>
   </data>
@@ -179,6 +182,9 @@
   </data>
   <data name="SABT_Label_EnableMotors" xml:space="preserve">
     <value>Motoren aktivieren</value>
+  </data>
+  <data name="SABT_Label_DisableActivationConfirmation" xml:space="preserve">
+    <value>Aktivierungsbestätigung deaktivieren</value>
   </data>
   <data name="SABT_Label_FlipChannels" xml:space="preserve">
     <value>Kanäle tauschen</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.fr-FR.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.fr-FR.resx
@@ -144,6 +144,9 @@
   <data name="SABT_Message_ActivationWarning" xml:space="preserve">
     <value>Les moteurs du tendeur de ceinture vont être activés. Continuer ?</value>
   </data>
+  <data name="SABT_Message_DisableActivationWarningWarning" xml:space="preserve">
+    <value>Cela désactivera l'invite de confirmation avant l'activation des moteurs ; n'activez cette option que si vous savez ce que vous faites. Continuer ?</value>
+  </data>
   <data name="SABT_Message_SimHubLicenseRequired" xml:space="preserve">
     <value>Votre installation SimHub n'est pas sous licence, les mises à jour de télémétrie seront donc limitées à 10 Hz</value>
   </data>
@@ -179,6 +182,9 @@
   </data>
   <data name="SABT_Label_EnableMotors" xml:space="preserve">
     <value>Activer les moteurs</value>
+  </data>
+  <data name="SABT_Label_DisableActivationConfirmation" xml:space="preserve">
+    <value>Désactiver l'invite de confirmation d'activation</value>
   </data>
   <data name="SABT_Label_FlipChannels" xml:space="preserve">
     <value>Inverser les canaux</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.it.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.it.resx
@@ -144,6 +144,9 @@
   <data name="SABT_Message_ActivationWarning" xml:space="preserve">
     <value>I motori del tensionatore cintura verranno attivati. Procedere?</value>
   </data>
+  <data name="SABT_Message_DisableActivationWarningWarning" xml:space="preserve">
+    <value>Questa opzione disabiliterà la richiesta di conferma prima dell'attivazione dei motori; abilitala solo se sai cosa stai facendo. Procedere?</value>
+  </data>
   <data name="SABT_Message_SimHubLicenseRequired" xml:space="preserve">
     <value>La tua installazione di SimHub non è licenziata, quindi gli aggiornamenti telemetrici saranno limitati a 10 Hz</value>
   </data>
@@ -179,6 +182,9 @@
   </data>
   <data name="SABT_Label_EnableMotors" xml:space="preserve">
     <value>Abilita motori</value>
+  </data>
+  <data name="SABT_Label_DisableActivationConfirmation" xml:space="preserve">
+    <value>Disabilita la richiesta di conferma di attivazione</value>
   </data>
   <data name="SABT_Label_FlipChannels" xml:space="preserve">
     <value>Inverti canali</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.resx
@@ -144,6 +144,9 @@
   <data name="SABT_Message_ActivationWarning" xml:space="preserve">
     <value>The belt tensioner motors will be activated. Proceed?</value>
   </data>
+  <data name="SABT_Message_DisableActivationWarningWarning" xml:space="preserve">
+    <value>This will disable the confirmation prompt before activating the motors; only enable this if you know what you are doing. Proceed?</value>
+  </data>
   <data name="SABT_Message_SimHubLicenseRequired" xml:space="preserve">
     <value>Your installation of SimHub is not licensed, so telemetry updates will be limited to 10Hz</value>
   </data>
@@ -179,6 +182,9 @@
   </data>
   <data name="SABT_Label_EnableMotors" xml:space="preserve">
     <value>Enable Motors</value>
+  </data>
+  <data name="SABT_Label_DisableActivationConfirmation" xml:space="preserve">
+    <value>Disable activation confirmation prompt</value>
   </data>
   <data name="SABT_Label_FlipChannels" xml:space="preserve">
     <value>Flip Channels</value>


### PR DESCRIPTION
https://github.com/GeorgeWilkins/Simple-Active-Belt-Tensioner/issues/29

This PR adds a new action `toggleSabtMotors` which toggles the activation state of the motors, so the action can be bound to another SimHub action (like a control). This also includes a new setting `DisableActivationConfirmation` which disables the MessageBox prompt that appears when toggling the motors to the active state (and requires confirmation) so that the new `toggleSabtMotors` action works without further interaction. Activation of `DisableActivationConfirmation` has its own MessageBox that warns users about this, and requires confirmation as well.

The translations I've just done through Google Translate so I've got no idea how good they are, sorry!