### PR TITLE
Fix/stay enabled on game change

### DIFF
--- a/Sources/Plugin/DeviceControl.xaml
+++ b/Sources/Plugin/DeviceControl.xaml
@@ -31,7 +31,7 @@
                                 <StackPanel>
                                     <TextBlock TextWrapping="WrapWithOverflow" Margin="0,0,0,20">
                                             <Label Content="{SLoc SABT_Label_EnableMotors}" Margin="-5,0,0,0" />
-                                            <styles:SHToggleCheckbox IsChecked="{Binding Settings.IsEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding Settings.IsSerialPortValid}" />
+                                            <styles:SHToggleCheckbox IsChecked="{Binding IsEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding Settings.IsSerialPortValid}" />
                                             <Label Content="{SLoc SABT_Label_StartAutomatically}" Margin="-5,0,0,0" />
                                             <styles:SHToggleCheckbox IsChecked="{Binding Settings.StartAutomatically, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                             <Label Content="{SLoc SABT_Label_FlipChannels}" Margin="-5,0,0,0" />

--- a/Sources/Plugin/DeviceControl.xaml.cs
+++ b/Sources/Plugin/DeviceControl.xaml.cs
@@ -27,7 +27,6 @@ namespace User.ActiveBeltTensioner
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
 
-            _plugin.Settings.IsEnabled = (_plugin.Settings.IsEnabled && _plugin.Settings.StartAutomatically);
             _plugin.Settings.PropertyChanged += OnPropertyChanged;
 
             _updateSerialPortsTimer = new DispatcherTimer
@@ -52,7 +51,8 @@ namespace User.ActiveBeltTensioner
             DataContext = new DeviceViewModel(
                 _plugin.Settings,
                 _plugin.MotorController,
-                _plugin.TelemetryGraphModel
+                _plugin.TelemetryGraphModel,
+                _plugin
             );
 
             _plugin.DoWithoutWaiting(

--- a/Sources/Plugin/DevicePlugin.cs
+++ b/Sources/Plugin/DevicePlugin.cs
@@ -79,6 +79,8 @@ namespace User.ActiveBeltTensioner
             Settings = this.ReadCommonSettings<DeviceSettings>(_settingsName, () => new DeviceSettings());
             Settings.PropertyChanged += OnSettingsChanged;
 
+            IsEnabled = Settings.StartAutomatically;
+
             // Register Actions (For External Control)
             pluginManager.AddAction(
                 actionName: "SABT.ToggleMotors",

--- a/Sources/Plugin/DevicePlugin.cs
+++ b/Sources/Plugin/DevicePlugin.cs
@@ -19,7 +19,7 @@ namespace User.ActiveBeltTensioner
     [PluginDescription("A control panel for the 'Simple Active Belt Tensioner'")]
     [PluginAuthor("George Wilkins")]
     [PluginName("Simple Active Belt Tensioner")]
-    public class DevicePlugin : IPlugin, IDataPlugin, IWPFSettingsV2
+    public class DevicePlugin : IPlugin, IDataPlugin, IWPFSettingsV2, IReusable
     {
         const string IsEnabledPropertyName = "IsEnabled";
 
@@ -598,6 +598,12 @@ namespace User.ActiveBeltTensioner
             TelemetryGraphModel.Series.Add(series);
 
             return series;
+        }
+
+        public void FinalizePlugin()
+        {
+            // Do nothing here because we're already doing the cleanup in End
+            Logging.Current.Info($"SABT: Finalizing plugin");
         }
     }
 }

--- a/Sources/Plugin/DevicePlugin.cs
+++ b/Sources/Plugin/DevicePlugin.cs
@@ -21,6 +21,8 @@ namespace User.ActiveBeltTensioner
     [PluginName("Simple Active Belt Tensioner")]
     public class DevicePlugin : IPlugin, IDataPlugin, IWPFSettingsV2
     {
+        const string IsEnabledPropertyName = "IsEnabled";
+
         public DeviceSettings Settings;
 
         public PluginManager PluginManager { get; set; }
@@ -28,7 +30,6 @@ namespace User.ActiveBeltTensioner
         public ImageSource PictureIcon => this.ToIcon(Properties.Resources.MenuIcon);
 
         public string LeftMenuTitle => SLoc.GetValue("SABT_Plugin");
-
 
         public MotorController MotorController;
 
@@ -44,6 +45,7 @@ namespace User.ActiveBeltTensioner
         private volatile bool _runControlLoop = false;
         private volatile bool _hasBeenInactive = true;
         private volatile bool _hasBypassedActivationWarning = false;
+        private volatile bool _isEnabled = false;
 
         public struct TelemetrySnapshot
         {
@@ -53,6 +55,14 @@ namespace User.ActiveBeltTensioner
             public double? Speed;
             public bool DidUpshift;
             public bool IsActive;
+        }
+
+        public bool IsEnabled {
+            get => _isEnabled;
+            set {
+                _isEnabled = value;
+                OnSettingsChanged(this, new PropertyChangedEventArgs(IsEnabledPropertyName));
+            } 
         }
 
         public System.Windows.Controls.Control GetWPFSettingsControl(PluginManager pluginManager)
@@ -75,7 +85,7 @@ namespace User.ActiveBeltTensioner
                 actionStart: (PluginManager manager, string input) => {
                     Logging.Current.Info("SABT: Toggling motors from external input");
                     _hasBypassedActivationWarning = false;
-                    Settings.IsEnabled = !Settings.IsEnabled;
+                    IsEnabled = !IsEnabled;
                 }
             );
 
@@ -83,14 +93,14 @@ namespace User.ActiveBeltTensioner
                 actionName: "SABT.ToggleMotorsWithoutWarning",
                 actionStart: (PluginManager manager, string input) => {
                     Logging.Current.Info("SABT: Toggling motors from external input (without warning)");
-                    _hasBypassedActivationWarning = Settings.IsEnabled ? false : true;
-                    Settings.IsEnabled = !Settings.IsEnabled;
+                    _hasBypassedActivationWarning = IsEnabled ? false : true;
+                    IsEnabled = !IsEnabled;
                 }
             );
 
             // Initialise Motor Controller
             MotorController = new MotorController(this);
-            if (Settings.IsEnabled && Settings.IsSerialPortValid)
+            if (IsEnabled && Settings.IsSerialPortValid)
             {
                 DoWithoutWaiting(devicePlugin =>
                 {
@@ -118,10 +128,10 @@ namespace User.ActiveBeltTensioner
         {
             if (
                 e.PropertyName == nameof(Settings.SerialPort) ||
-                e.PropertyName == nameof(Settings.IsEnabled)
+                e.PropertyName == IsEnabledPropertyName
             )
             {
-                if (Settings.IsEnabled)
+                if (IsEnabled)
                 {
                     if (Settings.IsSerialPortValid)
                     {
@@ -158,7 +168,7 @@ namespace User.ActiveBeltTensioner
         /// <summary>Called by SimHub when new telemetry data is available</summary>
         public void DataUpdate(PluginManager pluginManager, ref GameData data)
         {
-            if (!Settings.IsEnabled) { return; }
+            if (!IsEnabled) { return; }
 
             short oldGear = 0;
             short newGear = 0;
@@ -194,7 +204,7 @@ namespace User.ActiveBeltTensioner
 
         /// <summary>Called by SimHub when the plugin is unloaded, allowing the graceful release of connections and resources</summary>
         public void End(PluginManager pluginManager)
-        {
+        {   
             this.SaveCommonSettings(_settingsName, Settings);
 
             _runControlLoop = false;
@@ -222,7 +232,7 @@ namespace User.ActiveBeltTensioner
 
                 _hasTelemetryArrived.WaitOne();
 
-                if (!Settings.IsEnabled)
+                if (!IsEnabled)
                 {
                     _hasBeenInactive = true;
 
@@ -259,7 +269,7 @@ namespace User.ActiveBeltTensioner
 
                         if (result != MessageBoxResult.Yes)
                         {
-                            Settings.IsEnabled = false;
+                            IsEnabled = false;
 
                             continue;
                         }
@@ -394,7 +404,7 @@ namespace User.ActiveBeltTensioner
                                 MessageBoxImage.Warning
                             );
 
-                            Settings.IsEnabled = false;
+                            IsEnabled = false;
                         }
                     }
                 }

--- a/Sources/Plugin/DeviceSettings.cs
+++ b/Sources/Plugin/DeviceSettings.cs
@@ -30,20 +30,6 @@ namespace User.ActiveBeltTensioner
             }
         }
 
-        private bool _isEnabled = false;
-        public bool IsEnabled
-        {
-            get { return _isEnabled; }
-            set
-            {
-                if (_isEnabled != value)
-                {
-                    _isEnabled = value;
-                    InvokePropertyChange(nameof(IsEnabled));
-                }
-            }
-        }
-
         private bool _startAutomatically = false;
         public bool StartAutomatically
         {

--- a/Sources/Plugin/DeviceViewModel.cs
+++ b/Sources/Plugin/DeviceViewModel.cs
@@ -9,16 +9,25 @@ namespace User.ActiveBeltTensioner
 {
     public class DeviceViewModel
     {
+        private readonly DevicePlugin _pluginInstance;
+
         public DeviceSettings Settings { get; }
         public MotorController MotorController { get; }
         public PlotModel TelemetryGraphModel { get; }
+        
+        public bool IsEnabled {
+            get => _pluginInstance.IsEnabled;
+            set => _pluginInstance.IsEnabled = value;
+        }
 
         public DeviceViewModel(
             DeviceSettings settings,
             MotorController motorController,
-            PlotModel telemetryGraphModel
+            PlotModel telemetryGraphModel,
+            DevicePlugin pluginInstance
         )
         {
+            _pluginInstance = pluginInstance;
             Settings = settings;
             MotorController = motorController;
             TelemetryGraphModel = telemetryGraphModel;

--- a/Sources/Plugin/MotorController.cs
+++ b/Sources/Plugin/MotorController.cs
@@ -566,7 +566,7 @@ namespace User.ActiveBeltTensioner
         {
             if (_serialPort != null && _serialPort.IsOpen)
             {
-                if (_plugin.Settings.IsEnabled && !IsBusy)
+                if (_plugin.IsEnabled && !IsBusy)
                 {
                     Check();
                 }
@@ -606,7 +606,7 @@ namespace User.ActiveBeltTensioner
 
             EndAction(action);
 
-            if (didConnect && _plugin.Settings.IsEnabled)
+            if (didConnect && _plugin.IsEnabled)
             {
                 Check();
             }


### PR DESCRIPTION
#21 

It looks like the base issue was that when `DeviceControl.OnLoaded` was reinitialised (when the game changes) it would update the `Settings.IsEnabled = Settings.IsEnabled && Settings.StartAutomatically` and if you didn't have `StartAutomatically` enabled it would disable during the game switch.

If we remove that assignment it all works - but there's a less-than-ideal if you exit SimHub with the plugin enabled and reopen as it'll immediately prompt you to confirm turning the motors on, because the `IsEnabled` setting is persisted. 

What I've done in this PR is to move that `IsEnabled` state _out_ of `Settings` and instead have it as a local variable in inside `DevicePlugin` with the initial value being `StartAutomatically`. SimHub has been destroying the `DevicePlugin` instance whenever the game changes and so we'd lose that local instance state - but having the plugin implement `IReusable` means SimHub won't create a new instance when reactivating the plugin and instead use the existing instance. The only fn that needs to be implemented is just a stub because you already do the cleanup in `End` (which is called every time the plugin is unloaded` and `Create` will re-up everything and start the control loop.

Having `IsEnabled` be part of the `DevicePlugin` lifecycle and it not being persisted also means we're in a slightly safer place w.r.t. unexpected exits of SimHub since the motors will always default to an off state (unless `StartAutomatically` is enabled) - but of course the dialog still exists so is more a belt-and-braces sort of thing.