### PR TITLE
Expose plugin state as SimHub properties and add gain control actions

### DIFF
--- a/Sources/Plugin/DeviceControl.xaml
+++ b/Sources/Plugin/DeviceControl.xaml
@@ -10,6 +10,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins"
     xmlns:ui="clr-namespace:SimHub.Plugins.UI;assembly=SimHub.Plugins"
+    xmlns:mah="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:oxy="http://oxyplot.org/wpf"
     d:DataContext="{d:DesignInstance Type=local:DeviceViewModel}"
     mc:Ignorable="d"
@@ -120,6 +121,11 @@
 
                                 <ui:TitledRangeSlider Title="{SLoc SABT_Label_DrivingTension}" Maximum="1000" Minimum="0" LowerValue="{Binding Settings.MinimumTension, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" UpperValue="{Binding Settings.MaximumTension, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock LineHeight="20" TextWrapping="WrapWithOverflow" Margin="5,0,0,5" Text="{SLoc SABT_Text_DrivingTension}" />
+                                <DockPanel Margin="5,4,5,4">
+                                    <mah:NumericUpDown DockPanel.Dock="Right" Width="100" Minimum="10" Maximum="200" Value="{Binding Settings.GainStep, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Text="{SLoc SABT_Label_GainStep}" VerticalAlignment="Center" />
+                                </DockPanel>
+                                <TextBlock LineHeight="20" TextWrapping="WrapWithOverflow" Margin="5,0,0,5" Text="{SLoc SABT_Text_GainStep}" />
 
                                 <styles:SHSectionSeparator />
 

--- a/Sources/Plugin/DevicePlugin.cs
+++ b/Sources/Plugin/DevicePlugin.cs
@@ -255,6 +255,28 @@ namespace User.ActiveBeltTensioner
                 }
             );
 
+            pluginManager.AddAction(
+                actionName: "SABT.IncreaseGain",
+                actionStart: (PluginManager manager, string input) => {
+                    Logging.Current.Info("SABT: Increasing gain from external input");
+                    Settings.MaximumTension = Math.Min(Settings.MaximumTension + Settings.GainStep, 1000);
+                    Settings.Persist?.Invoke();
+                }
+            );
+
+            pluginManager.AddAction(
+                actionName: "SABT.DecreaseGain",
+                actionStart: (PluginManager manager, string input) => {
+                    Logging.Current.Info("SABT: Decreasing gain from external input");
+                    Settings.MaximumTension -= Settings.GainStep;
+                    Settings.Persist?.Invoke();
+                }
+            );
+
+            // Expose Properties
+            pluginManager.AttachDelegate("SABT.MotorsAreEnabled", typeof(DevicePlugin), () => IsEnabled);
+            pluginManager.AttachDelegate("SABT.GlobalGain", typeof(DevicePlugin), () => Settings.MaximumTension / 10.0);
+
             // Initialise Motor Controller
             MotorController = new MotorController(this);
             if (IsEnabled && Settings.IsSerialPortValid)

--- a/Sources/Plugin/DeviceSettings.cs
+++ b/Sources/Plugin/DeviceSettings.cs
@@ -155,6 +155,20 @@ namespace User.ActiveBeltTensioner
             }
         }
 
+        private int _gainStep = 50;
+        public int GainStep
+        {
+            get { return _gainStep; }
+            set
+            {
+                if (_gainStep != value)
+                {
+                    _gainStep = Math.Max(value, 1);
+                    InvokePropertyChange(nameof(GainStep));
+                }
+            }
+        }
+
         private int _minimumSurge = -8;
         public int MinimumSurge
         {

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.de-DE.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.de-DE.resx
@@ -355,6 +355,10 @@
 • Ein höheres Minimum erzeugt eine konstante Spannung und verstärkt Beschleunigungs- und Sprungeffekte
 • Ein niedrigeres Maximum reduziert die gesamte Spannungsstärke</value>
   </data>
+  <data name="SABT_Text_GainStep" xml:space="preserve">
+    <value>• Änderung der maximalen Spannung pro Aktion 'Verstärkung erhöhen/verringern'
+• Ein Schritt von 50 entspricht einer Änderung von 5 % der Gesamtverstärkung</value>
+  </data>
   <data name="SABT_Text_LeftRightBias" xml:space="preserve">
     <value>• Wenn die Spannung zwischen den Seiten unausgewogen wirkt, nach links oder rechts anpassen
 • Prüfen und korrigieren Sie zuerst den Gurtverlauf und die Kontaktpunkte, bevor Sie diese Einstellung verwenden</value>
@@ -403,6 +407,9 @@
   </data>
   <data name="SABT_Label_DrivingTension" xml:space="preserve">
     <value>Fahrspannung</value>
+  </data>
+  <data name="SABT_Label_GainStep" xml:space="preserve">
+    <value>Verstärkungsschritt</value>
   </data>
   <data name="SABT_Label_LeftRightBias" xml:space="preserve">
     <value>Links/Rechts-Balance</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.fr-FR.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.fr-FR.resx
@@ -355,6 +355,10 @@
 • Augmenter le minimum applique une tension constante et renforce les effets d'accélération et de saut
 • Réduire le maximum diminue l'intensité globale de tension</value>
   </data>
+  <data name="SABT_Text_GainStep" xml:space="preserve">
+    <value>• Variation de tension maximale pour chaque action Augmenter/Diminuer le gain
+• Un pas de 50 correspond à une variation de 5 % du gain global</value>
+  </data>
   <data name="SABT_Text_LeftRightBias" xml:space="preserve">
     <value>• Si la tension semble déséquilibrée, ajustez vers la gauche ou la droite
 • Vérifiez d'abord le cheminement de la ceinture et les points de contact avant d'utiliser ce réglage</value>
@@ -403,6 +407,9 @@
   </data>
   <data name="SABT_Label_DrivingTension" xml:space="preserve">
     <value>Tension en conduite</value>
+  </data>
+  <data name="SABT_Label_GainStep" xml:space="preserve">
+    <value>Pas de gain</value>
   </data>
   <data name="SABT_Label_LeftRightBias" xml:space="preserve">
     <value>Équilibre gauche/droite</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.it.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.it.resx
@@ -355,6 +355,10 @@
 • Aumentare il minimo applica una tensione costante e migliora gli effetti di accelerazione e salti
 • Ridurre il massimo riduce l'intensità complessiva della tensione</value>
   </data>
+  <data name="SABT_Text_GainStep" xml:space="preserve">
+    <value>• Variazione della tensione massima per ogni azione Aumenta/Diminuisci guadagno
+• Un passo di 50 corrisponde a una variazione del 5% del guadagno complessivo</value>
+  </data>
   <data name="SABT_Text_LeftRightBias" xml:space="preserve">
     <value>• Se la tensione sembra sbilanciata tra i lati, regola verso sinistra o destra
 • Controlla e correggi il percorso della cintura e i punti di contatto prima di usare questa impostazione</value>
@@ -403,6 +407,9 @@
   </data>
   <data name="SABT_Label_DrivingTension" xml:space="preserve">
     <value>Tensione in guida</value>
+  </data>
+  <data name="SABT_Label_GainStep" xml:space="preserve">
+    <value>Passo guadagno</value>
   </data>
   <data name="SABT_Label_LeftRightBias" xml:space="preserve">
     <value>Bilanciamento sinistra/destra</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.resx
@@ -355,6 +355,10 @@
 • Increasing the minimum will apply a constant tension and enhance acceleration and jumping effects
 • Reducing the maximum will result in a reduction of overall tension strength</value>
   </data>
+  <data name="SABT_Text_GainStep" xml:space="preserve">
+    <value>• How much the maximum tension changes with each Increase/Decrease Gain action
+• A step of 50 corresponds to a 5% change in overall gain</value>
+  </data>
   <data name="SABT_Text_LeftRightBias" xml:space="preserve">
     <value>• If tension feels unbalanced between sides, adjust this left or right to bias towards that side
 • Check and correct your belt path and contact points before resorting to using this setting</value>
@@ -403,6 +407,9 @@
   </data>
   <data name="SABT_Label_DrivingTension" xml:space="preserve">
     <value>Driving Tension</value>
+  </data>
+  <data name="SABT_Label_GainStep" xml:space="preserve">
+    <value>Gain Step</value>
   </data>
   <data name="SABT_Label_LeftRightBias" xml:space="preserve">
     <value>Left/Right Bias</value>


### PR DESCRIPTION
# Summary

Three new SimHub properties are registered in Init() via AttachDelegate:
- SABT.MotorsAreEnabled (bool) — mirrors the Enable Motors toggle on the Connection screen; allows dashboards and other plugins to read whether the belt tensioner is currently active.
- SABT.GlobalGain (double, 0–100) — the upper limit of the driving tension range expressed as a percentage, matching the scale used by ShakeIt Motors / Bass Shakers (MaximumTension / 10.0).

Two new actions are registered via AddAction:
- SABT.IncreaseGain — raises MaximumTension by GainStep (capped at 1000) and persists the updated setting immediately.
- SABT.DecreaseGain — lowers MaximumTension by GainStep (floored at MinimumTension by the existing setter) and persists.

A new GainStep setting (int, default 50 = 5% per step) is added to DeviceSettings. It is exposed in the Tension tab as a compact numeric spinner (MahApps NumericUpDown, fixed 100 px wide) placed directly under the Driving Tension description, keeping the full-width slider layout clean. Range is 10–200.

Translation strings (SABT_Label_GainStep, SABT_Text_GainStep) added to all four language files (EN, FR, DE, IT).

# New properties and actions

New properties visible in Available Properties:
<img width="776" height="226" alt="Screenshot 2026-06-08 215505" src="https://github.com/user-attachments/assets/1e24781f-6079-4375-805c-5509c3038d9a" />

New actions visible in Controls and Events:
<img width="720" height="277" alt="Screenshot 2026-06-08 215541" src="https://github.com/user-attachments/assets/4579727e-0596-407d-b306-0f48028848ab" />

New gain setting in the Tension tab:
<img width="1405" height="637" alt="Screenshot 2026-06-08 215153" src="https://github.com/user-attachments/assets/1752030b-86f7-4708-97f6-9d75212eb80c" />

# E2E Demonstration

I have a StreamDeck+ to control SimHub peripherals. [This plugin](https://github.com/pre-martin/SimHubPropertyServer) exposes SimHub profiles on localhost (to Stream Deck), and [this plugin](https://github.com/pre-martin/StreamDeckSimHubPlugin) allows triggering SimHub actions from Stream Deck.

The video shows activating, deactivating, and adjusting the gain using Stream deck. The settings were reflected in the plugin UI, and physically enabled/disabled the motors.

https://github.com/user-attachments/assets/7a5712c4-7f25-40b1-a4a2-8fe7b7ef1fc1



