### PR TITLE
[Issue 57] fix(setup): assign motor IDs reliably on clone DDSM motors

### DIFF
--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.de-DE.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.de-DE.resx
@@ -181,7 +181,19 @@
     <value>Jetzt müssen Sie NUR DEN LINKEN MOTOR ANSCHLIESSEN. Jeder Anschluss am Controller ist geeignet. Schalten Sie danach die Stromversorgung ein. Haben Sie das getan?</value>
   </data>
   <data name="SABT_Message_Setup_PlugInRightMotor" xml:space="preserve">
-    <value>Super, der LINKE MOTOR wurde konfiguriert. Schließen Sie jetzt den RECHTEN MOTOR an und lassen Sie den anderen Motor weiterhin verbunden. Haben Sie das getan?</value>
+      <value>Sehr gut, der LINKE MOTOR wurde konfiguriert. Als nächstes SCHALTEN SIE DEN STROM AB, STECKEN Sie den LINKEN MOTOR ab und verbinden NUR DEN RECHTEN MOTOR. Danach schalten Sie den Strom wieder an. Erledigt?</value>
+  </data>
+  <data name="SABT_Message_Setup_PowerCycleToSwap" xml:space="preserve">
+    <value>Beide Motoren wurden einzeln konfiguriert. Danach STROM ABSCHALTEN, BEIDE MOTOREN anstecken, Strom wieder anschalten. Erledigt?</value>
+  </data>
+  <data name="SABT_Message_Setup_NoMotorOnBus" xml:space="preserve">
+    <value>Kein Motor wurde über den Bus erkannt. Dies könnte bedeuten, dass kein Motor verbunden ist, oder, dass zwei Motoren, die dieselbe ID besitzen, im Konflikt stehen. Stellen Sie sicher, dass genau EIN Motor verbunden und angeschalten ist. Drücken Sie anschließend OK, um die Suche erneut zu starten.</value>
+  </data>
+  <data name="SABT_Message_Setup_MultipleMotorsOnBus" xml:space="preserve">
+    <value>Mehrere Motoren wurden über den Bus gefunden. Stellen Sie sicher, dass nur EIN Motor zu diesem Zeitpunkt angeschlossen ist. Drücken Sie anschließend OK, um die Suche erneut zu starten.</value>
+  </data>
+  <data name="SABT_Message_Setup_VerifyFailed" xml:space="preserve">
+    <value>Abschließende Verifizierung gescheitert - Kein Motor hat die erwarteten IDs ausgegeben. Bitte starten Sie das Setup erneut. </value>
   </data>
   <data name="SABT_Message_Setup_AlreadySetUp" xml:space="preserve">
     <value>Es scheint bereits alles korrekt eingerichtet zu sein (beide Motoren sind verbunden)!</value>

--- a/Sources/Plugin/Languages/User.ActiveBeltTensioner.resx
+++ b/Sources/Plugin/Languages/User.ActiveBeltTensioner.resx
@@ -181,7 +181,19 @@
     <value>Now we need to PLUG IN THE LEFT MOTOR ONLY. Any of the ports on the controller will do. Once connected, plug in the power. Have you done this?</value>
   </data>
   <data name="SABT_Message_Setup_PlugInRightMotor" xml:space="preserve">
-    <value>Great, the LEFT MOTOR has been configured. Now PLUG IN THE RIGHT MOTOR, leaving the other motor still connected. Have you done this?</value>
+    <value>Great, the LEFT MOTOR has been configured. Now TURN OFF THE POWER, UNPLUG THE LEFT MOTOR, and connect ONLY THE RIGHT MOTOR. Then power back on. Have you done this?</value>
+  </data>
+  <data name="SABT_Message_Setup_PowerCycleToSwap" xml:space="preserve">
+    <value>Both motors have been configured individually. Now TURN OFF THE POWER, plug in BOTH MOTORS, and power back on. Have you done this?</value>
+  </data>
+  <data name="SABT_Message_Setup_NoMotorOnBus" xml:space="preserve">
+    <value>No motor was detected on the bus. This may mean no motor is connected, or two motors sharing the same ID are colliding. Ensure exactly ONE motor is connected and powered, then click OK to scan again.</value>
+  </data>
+  <data name="SABT_Message_Setup_MultipleMotorsOnBus" xml:space="preserve">
+    <value>More than one motor was detected on the bus. Ensure only ONE motor is connected at this step, then click OK to scan again.</value>
+  </data>
+  <data name="SABT_Message_Setup_VerifyFailed" xml:space="preserve">
+    <value>Final verification failed — both motors did not respond with the expected IDs. Please run Setup again.</value>
   </data>
   <data name="SABT_Message_Setup_AlreadySetUp" xml:space="preserve">
     <value>You appear to already be set up correctly (both motors are connected)!</value>

--- a/Sources/Plugin/MotorController.cs
+++ b/Sources/Plugin/MotorController.cs
@@ -456,12 +456,52 @@ namespace User.ActiveBeltTensioner
         /// <returns>Whether the process succeeded</returns>
         public bool Setup()
         {
+            StartAction(out string action);
+
+            try
+            {
+                return DoSetup();
+            }
+            finally
+            {
+                EndAction(action);
+            }
+        }
+
+        private bool DoSetup()
+        {
+            // Disable motors and disconnect cleanly before doing anything —
+            // prevents the control loop from interleaving commands during setup
             _plugin.IsEnabled = false;
+            Disconnect();
 
-            Connect();
+            if (!_plugin.Settings.IsSerialPortValid || !Connect())
+            {
+                MessageBox.Show(
+                    SLoc.GetValue("SABT_Message_NoDeviceDetected"),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Exclamation
+                );
 
-            Motor leftMotor = GetLeftMotor();
-            Motor rightMotor = GetRightMotor();
+                return false;
+            }
+
+            if (Motors.All(m => m.IsConnected))
+            {
+                MessageBox.Show(
+                    SLoc.GetValue("SABT_Message_Setup_AlreadySetUp"),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Exclamation
+                );
+
+                return false;
+            }
+
+            // Always use physical labels during setup — flip is a runtime mapping, not a wiring fact
+            Motor leftMotor = Motors.FirstOrDefault(m => m.Label == "Left");
+            Motor rightMotor = Motors.FirstOrDefault(m => m.Label == "Right");
 
             leftMotor.Status = SLoc.GetValue("SABT_Status_Disconnected");
             leftMotor.Graphic = MotorGraphic.Disconnected;
@@ -469,81 +509,164 @@ namespace User.ActiveBeltTensioner
             rightMotor.Status = SLoc.GetValue("SABT_Status_Disconnected");
             rightMotor.Graphic = MotorGraphic.Disconnected;
 
-            if (
+            if (MessageBox.Show(
+                SLoc.GetValue("SABT_Message_Setup_TurnOffPower"),
+                SLoc.GetValue("SABT_Plugin"),
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Information
+            ) != MessageBoxResult.Yes) return false;
+
+            leftMotor.Status = SLoc.GetValue("SABT_Status_AwaitingConnection");
+            leftMotor.Graphic = MotorGraphic.Connect;
+
+            if (MessageBox.Show(
+                SLoc.GetValue("SABT_Message_Setup_PlugInLeftMotor"),
+                SLoc.GetValue("SABT_Plugin"),
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Information
+            ) != MessageBoxResult.Yes) return false;
+
+            if (!WaitForSingleMotor()) return false;
+
+            if (!leftMotor.SetIdentifier())
+            {
                 MessageBox.Show(
-                    SLoc.GetValue("SABT_Message_Setup_TurnOffPower"),
+                    SLoc.GetValue("SABT_Message_Setup_FailedToSetLeftMotor"),
                     SLoc.GetValue("SABT_Plugin"),
-                    MessageBoxButton.YesNoCancel,
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+
+                return false;
+            }
+
+            List<byte> afterLeft = ScanBus();
+
+            if (afterLeft.Count != 1 || afterLeft[0] != leftMotor.Identifier)
+            {
+                MessageBox.Show(
+                    SLoc.GetValue("SABT_Message_Setup_FailedToSetLeftMotor"),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+
+                return false;
+            }
+
+            rightMotor.Status = SLoc.GetValue("SABT_Status_AwaitingConnection");
+            rightMotor.Graphic = MotorGraphic.Connect;
+
+            if (MessageBox.Show(
+                SLoc.GetValue("SABT_Message_Setup_PlugInRightMotor"),
+                SLoc.GetValue("SABT_Plugin"),
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Information
+            ) != MessageBoxResult.Yes) return false;
+
+            if (!WaitForSingleMotor()) return false;
+
+            if (!rightMotor.SetIdentifier())
+            {
+                MessageBox.Show(
+                    SLoc.GetValue("SABT_Message_Setup_FailedToSetRightMotor"),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+
+                return false;
+            }
+
+            List<byte> afterRight = ScanBus();
+
+            if (afterRight.Count != 1 || afterRight[0] != rightMotor.Identifier)
+            {
+                MessageBox.Show(
+                    SLoc.GetValue("SABT_Message_Setup_FailedToSetRightMotor"),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
+
+                return false;
+            }
+
+            if (MessageBox.Show(
+                SLoc.GetValue("SABT_Message_Setup_PowerCycleToSwap"),
+                SLoc.GetValue("SABT_Plugin"),
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Information
+            ) != MessageBoxResult.Yes) return false;
+
+            List<byte> finalScan = ScanBus();
+            bool verified = finalScan.Count == 2
+                && finalScan.Contains(leftMotor.Identifier)
+                && finalScan.Contains(rightMotor.Identifier);
+
+            if (verified)
+            {
+                MessageBox.Show(
+                    SLoc.GetValue("SABT_Message_Setup_Complete"),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OK,
                     MessageBoxImage.Information
-                ) == MessageBoxResult.Yes
-            ) {
-                leftMotor.Status = SLoc.GetValue("SABT_Status_AwaitingConnection");
-                leftMotor.Graphic = MotorGraphic.Connect;
+                );
 
-                if (
-                    MessageBox.Show(
-                        SLoc.GetValue("SABT_Message_Setup_PlugInLeftMotor"),
-                        SLoc.GetValue("SABT_Plugin"),
-                        MessageBoxButton.YesNoCancel,
-                        MessageBoxImage.Information
-                    ) == MessageBoxResult.Yes
-                )
+                return true;
+            }
+
+            MessageBox.Show(
+                SLoc.GetValue("SABT_Message_Setup_VerifyFailed"),
+                SLoc.GetValue("SABT_Plugin"),
+                MessageBoxButton.OK,
+                MessageBoxImage.Error
+            );
+
+            return false;
+        }
+
+        /// <summary>Scans the bus until exactly one motor responds, prompting the user to correct the connection on each failure; returns false if the user cancels</summary>
+        private bool WaitForSingleMotor()
+        {
+            while (true)
+            {
+                List<byte> found = ScanBus();
+
+                if (found.Count == 1) return true;
+
+                string key = found.Count == 0
+                    ? "SABT_Message_Setup_NoMotorOnBus"
+                    : "SABT_Message_Setup_MultipleMotorsOnBus";
+
+                if (MessageBox.Show(
+                    SLoc.GetValue(key),
+                    SLoc.GetValue("SABT_Plugin"),
+                    MessageBoxButton.OKCancel,
+                    MessageBoxImage.Warning
+                ) != MessageBoxResult.OK) return false;
+            }
+        }
+
+        /// <summary>Queries each motor ID from 1 to <paramref name="maxId" /> and returns the IDs that respond with a valid status frame</summary>
+        private List<byte> ScanBus(byte maxId = 4)
+        {
+            List<byte> responders = new List<byte>();
+
+            for (byte id = 0; id <= maxId; id++)
+            {
+                FlushSerialBuffer();
+
+                byte[] tx = BuildFrame(id, 0x74);
+                byte[] rx = new byte[10];
+
+                if (WriteFrameReadFrame(tx, rx, 300, true, true) && rx[0] == id)
                 {
-                    if (!GetLeftMotor().SetIdentifier())
-                    {
-                        MessageBox.Show(
-                            SLoc.GetValue("SABT_Message_Setup_FailedToSetLeftMotor"),
-                            SLoc.GetValue("SABT_Plugin"),
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Error
-                        );
-
-                        return false;
-                    }
-
-                    rightMotor.Status = SLoc.GetValue("SABT_Status_AwaitingConnection");
-                    rightMotor.Graphic = MotorGraphic.Connect;
-
-                    if (
-                        MessageBox.Show(
-                            SLoc.GetValue("SABT_Message_Setup_PlugInRightMotor"),
-                            SLoc.GetValue("SABT_Plugin"),
-                            MessageBoxButton.YesNoCancel,
-                            MessageBoxImage.Information
-                        ) == MessageBoxResult.Yes
-                    )
-                    {
-                        if (!GetRightMotor().SetIdentifier())
-                        {
-                            MessageBox.Show(
-                                SLoc.GetValue("SABT_Message_Setup_FailedToSetRightMotor"),
-                                SLoc.GetValue("SABT_Plugin"),
-                                MessageBoxButton.OK,
-                                MessageBoxImage.Error
-                            );
-
-                            return false;
-                        }
-
-                        MessageBox.Show(
-                            SLoc.GetValue("SABT_Message_Setup_Complete"),
-                            SLoc.GetValue("SABT_Plugin"),
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Information
-                        );
-
-                        return true;
-                    }
+                    responders.Add(id);
                 }
             }
 
-            leftMotor.Status = SLoc.GetValue("SABT_Status_Disconnected");
-            leftMotor.Graphic = MotorGraphic.Disconnected;
-
-            rightMotor.Status = SLoc.GetValue("SABT_Status_Disconnected");
-            rightMotor.Graphic = MotorGraphic.Disconnected;
-
-            return false;
+            return responders;
         }
 
         /// <summary>Opens the selected serial port; checking motor communication automatically if enabled</summary>

--- a/Sources/Plugin/Properties/AssemblyInfo.cs
+++ b/Sources/Plugin/Properties/AssemblyInfo.cs
@@ -19,6 +19,6 @@ using System.Runtime.InteropServices;
  * format `{major}.{minor}.{build}.{revision}`, so just add `.0` to the end of the
  * actual release version number...
  */
-[assembly: AssemblyVersion("0.6.3.0")]
-[assembly: AssemblyFileVersion("0.6.3.0")]
-[assembly: AssemblyInformationalVersion("0.6.3")]
+[assembly: AssemblyVersion("0.6.4.0")]
+[assembly: AssemblyFileVersion("0.6.4.0")]
+[assembly: AssemblyInformationalVersion("0.6.4")]


### PR DESCRIPTION
## Problem

The ID-set command (`AA 55 53 <id>`) is an unaddressed RS485 broadcast —
every motor connected to the bus simultaneously will adopt the new ID.
Genuine Waveshare units silently work around this with a once-per-power-cycle
lock, but clone DFRobot DDSM motors honour the command every time, causing
both motors to end up with the same ID when the right motor is assigned while
the left is still connected.

Fixes #57

## Changes

- `Setup()` now wraps the wizard in `StartAction`/`EndAction` so `IsBusy` is
  set for the duration, preventing the control loop from interleaving torque
  commands with setup frames on the serial bus
- `DoSetup()` disables the plugin and disconnects cleanly before reconnecting,
  avoiding any residual serial state from the running session
- Motor lookup during setup now uses the physical `Label` field directly
  instead of `GetLeftMotor()`/`GetRightMotor()`, so the `IsFlipped` setting
  cannot cause the wrong motor to be assigned the wrong ID
- Added `ScanBus()` — queries IDs 0–4 with a 300ms timeout and returns all
  responders; used to verify isolation before and after each ID assignment
- Added `WaitForSingleMotor()` — loops until exactly one motor is on the bus,
  prompting the user to correct the connection if zero or multiple are detected
- Each motor's ID assignment is verified by a follow-up bus scan before
  proceeding to the next motor
- A final scan after both motors are connected confirms both IDs are present
  before declaring setup complete

Note: I had a friend do the German translation for me, not sure what your request is for new lc strings, I thought about google for IT & FR, but didn't want to put in slop haha.